### PR TITLE
Conditionally Install Extra Pip Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The path to the shell script that runs your integration tests. This path is rela
 
 **Optional**  
 Extra pip requirements to install in Open edX. These are additional Python packages your plugin depends on. Provide them as a space-separated string.  
-* *Default*: `""` (empty string)  
 * *Example*: `"package1==1.0 package2>=2.0"`
 
 ### `fixtures_file`

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,6 @@ inputs:
   openedx_extra_pip_requirements:
     description: "Optional extra pip requirements to install in Open edX. E.g: 'package1==1.0 package2>=2.0'"
     required: false
-    default: ""
   fixtures_file:
     description: "Optional path to the plugin's fixtures file to load."
     required: false
@@ -103,6 +102,7 @@ runs:
       shell: bash
 
     - name: Install extra requirements
+      if: ${{ inputs.openedx_extra_pip_requirements }}
       run: |
         source .tutor_venv/bin/activate
 


### PR DESCRIPTION
### Description
This PR introduces a conditional check for the `Install extra requirements` step in the GitHub Action workflow. The step now only runs if the input `openedx_extra_pip_requirements` is provided.

#### Changes:
- Added an `if` condition to the `Install extra requirements` step: 
  ```yaml
  if: ${{ inputs.openedx_extra_pip_requirements }}
  ```
- Removed default value in the input definition
- This ensures that extra pip requirements are installed only when the `openedx_extra_pip_requirements` input is specified

#### How has this been tested?
- A PR has been opened in the eox-tenant repository, pointing to this branch. The step to install the extra requirements passed successfully in the integration tests: [PR #220](https://github.com/eduNEXT/eox-tenant/pull/220).