### PR TITLE
feat: add steps to install custom tutor plugins and run extra tutor commands `AP-1527`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
           app_name: "eox-test"
           tutor_version: ${{ matrix.tutor_version }}
           tutor_plugins: "plugin1 plugin2"
+          tutor_extra_commands_path: "scripts/extra_commands.sh"
           shell_file_to_run: "tests/integration.sh"
           openedx_extra_pip_requirements: "package1==1.0 package2>=2.0"
           fixtures_file: "fixtures/test_data.json"
@@ -59,6 +60,12 @@ The python version to run the integration tests with. Make sure to use a version
 **Optional**  
 The list of Tutor Index plugins to install as a space-separated string. Only plugins available in the official Tutor plugin index can be installed using this option. For more information, you can refer to the [official Tutor documentation](https://docs.tutor.edly.io/reference/cli/plugins.html#tutor-plugins-install).
 * *Example*: `"plugin1 plugin2"`
+
+### `tutor_extra_commands_path`
+
+**Optional**
+The path to the shell script that contains Tutor extra commands to run after installing Tutor. This path is relative to your plugin directory.
+* *Example*: `"scripts/extra_commands.sh"`
 
 ### `shell_file_to_run`
 
@@ -142,7 +149,9 @@ specified in `tutor_plugins`.
     # Use DEMO_COURSE_ID in your tests
     ```
 
-20. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
+20. **Run Tutor Extra Commands** *(Optional)*: Executes the shell script specified in `tutor_extra_commands_path` to run additional Tutor commands after installing Tutor.
+`
+21. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
 
 ## Notes
 
@@ -151,7 +160,7 @@ specified in `tutor_plugins`.
 
 - **Paths**: Ensure that the paths provided in the inputs are relative to your plugin directory.
 
-- **Optional Steps**: Steps involving `openedx_imports_test_file_path` and `fixtures_file` are optional and will only run if the corresponding inputs are provided.
+- **Optional Steps**: Steps involving `openedx_imports_test_file_path`, `fixtures_file`, `tutor_extra_commands_path` and `tutor_plugins` are optional and will only run if the corresponding inputs are provided.
 
 - **Tutor Versions**: Use the matrix strategy to test your plugin against multiple Tutor versions, including the nightly build.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The python version to run the integration tests with. Make sure to use a version
 ### `tutor_plugins`
 
 **Optional**  
-The list of Tutor Index plugins to install. Refer to the [official Tutor documentation](https://docs.tutor.edly.io/reference/cli/plugins.html#tutor-plugins-install). Only plugins available in the official Tutor plugin index can be installed using this option. Provide them as a space-separated string.
+The list of Tutor Index plugins to install as a space-separated string. Only plugins available in the official Tutor plugin index can be installed using this option. For more information, you can refer to the [official Tutor documentation](https://docs.tutor.edly.io/reference/cli/plugins.html#tutor-plugins-install).
 * *Example*: `"plugin1 plugin2"`
 
 ### `shell_file_to_run`

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ This GitHub Action automates the process of setting up a Tutor Open edX environm
 7. **Install and Enable Tutor Plugins**: Installs and enables the specified Tutor plugins
 specified in `tutor_plugins`.
 
-8. **Launch Tutor**: Launches the Open edX platform using Tutor with the specified configuration.
+8. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
 
-9. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
+9. **Launch Tutor**: Launches the Open edX platform using Tutor with the specified configuration.
 
 10. **Add Mount for Plugin**: Mounts your plugin into the LMS and CMS containers.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The python version to run the integration tests with. Make sure to use a version
 ### `tutor_plugins`
 
 **Optional**  
-The list of Tutor Index plugins to install. Only plugins available in the official Tutor plugin index can be installed using this option. Provide them as a space-separated string.
+The list of Tutor Index plugins to install. Refer to the [official Tutor documentation](https://docs.tutor.edly.io/reference/cli/plugins.html#tutor-plugins-install). Only plugins available in the official Tutor plugin index can be installed using this option. Provide them as a space-separated string.
 * *Example*: `"plugin1 plugin2"`
 
 ### `shell_file_to_run`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jobs:
         with:
           app_name: "eox-test"
           tutor_version: ${{ matrix.tutor_version }}
+          tutor_plugins: "plugin1 plugin2"
           shell_file_to_run: "tests/integration.sh"
           openedx_extra_pip_requirements: "package1==1.0 package2>=2.0"
           fixtures_file: "fixtures/test_data.json"
@@ -52,6 +53,12 @@ The version of Tutor where you want to run the integration tests. You can specif
 
 **Optional**  
 The python version to run the integration tests with. Make sure to use a version fully supported by the plugin.
+
+### `tutor_plugins`
+
+**Optional**  
+The list of Tutor plugins to install. Provide them as a space-separated string.  
+* *Example*: `"plugin1 plugin2"`
 
 ### `shell_file_to_run`
 
@@ -92,33 +99,37 @@ This GitHub Action automates the process of setting up a Tutor Open edX environm
 
 5. **Create Virtual Environments**: Creates isolated Python virtual environments for installing Tutor and for running the integration tests.
 
-6. **Install and Prepare Tutor**: Installs the specified version of Tutor and launches the Open edX platform.
+6. **Install and Prepare Tutor**: Installs the specified version of Tutor.
    
    - If `tutor_version` is set to `"nightly"`, clones the Tutor repository from the `nightly` branch.
    - Saves Tutor configuration.
-   - Launches Tutor in interactive mode.
 
-7. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
+7. **Install and Enable Tutor Plugins**: Installs and enables the specified Tutor plugins
+specified in `tutor_plugins`.
 
-8. **Add Mount for Plugin**: Mounts your plugin into the LMS and CMS containers.
+8. **Launch Tutor**: Launches the Open edX platform using Tutor with the specified configuration.
 
-9. **Restart Tutor Services**: Stops and starts Tutor services to apply the new mounts.
+9. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
 
-10. **Install Open edX Plugin as an Editable Package**: Installs your plugin in editable mode inside both LMS and CMS containers.
+10. **Add Mount for Plugin**: Mounts your plugin into the LMS and CMS containers.
 
-11. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
+11. **Restart Tutor Services**: Stops and starts Tutor services to apply the new mounts.
 
-12. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
+12. **Install Open edX Plugin as an Editable Package**: Installs your plugin in editable mode inside both LMS and CMS containers.
 
-13. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
+13. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
 
-14. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
+14. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
 
-15. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
+15. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
 
-16. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
+16. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
 
-17. **Set `DEMO_COURSE_ID` Environment Variable**:  
+17. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
+
+18. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
+
+19. **Set `DEMO_COURSE_ID` Environment Variable**:  
     Sets the `DEMO_COURSE_ID` environment variable based on the Tutor version. This variable allows you to refer to the demo course in your tests, which can be helpful when you need to interact with course content during testing.
     
     **Usage in Your Tests**:  
@@ -131,7 +142,7 @@ This GitHub Action automates the process of setting up a Tutor Open edX environm
     # Use DEMO_COURSE_ID in your tests
     ```
 
-18. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
+20. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The python version to run the integration tests with. Make sure to use a version
 ### `tutor_plugins`
 
 **Optional**  
-The list of Tutor plugins to install. Provide them as a space-separated string.  
+The list of Tutor Index plugins to install. Only plugins available in the official Tutor plugin index can be installed using this option. Provide them as a space-separated string.
 * *Example*: `"plugin1 plugin2"`
 
 ### `shell_file_to_run`

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,7 @@ runs:
         source .tutor_venv/bin/activate
 
         tutor plugins update
+        tutor plugins install ${{ inputs.tutor_plugins }}
         tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -64,16 +64,6 @@ runs:
         python -m venv .tests_venv
       shell: bash
 
-    - name: Install and enable Tutor plugins
-      if: ${{ inputs.tutor_plugins }}
-      run: |
-        source .tutor_venv/bin/activate
-
-        tutor plugins update
-        tutor plugins install ${{ inputs.tutor_plugins }}
-        tutor plugins enable ${{ inputs.tutor_plugins }}
-      shell: bash
-
     - name: Install and prepare Tutor
       env:
         INPUT_TUTOR_VERSION: ${{ inputs.tutor_version }}
@@ -88,6 +78,20 @@ runs:
         fi
 
         tutor config save --set LMS_HOST=$LMS_HOST --set CMS_HOST=$CMS_HOST
+      shell: bash
+
+    - name: Install and enable Tutor plugins
+      if: ${{ inputs.tutor_plugins }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        tutor plugins update
+        tutor plugins install ${{ inputs.tutor_plugins }}
+        tutor plugins enable ${{ inputs.tutor_plugins }}
+      shell: bash
+
+    - name: Launch Tutor
+      run: |
         tutor local launch -I
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: '3.11'
   tutor_plugins:
-    description: "The list of Tutor plugins to install. E.g: 'plugin1 plugin2'"
+    description: "The list of Tutor indexed plugins to install. E.g: 'plugin1 plugin2'"
     required: false
   shell_file_to_run:
     description: "The path of the shell file to run the integration tests."

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,13 @@ runs:
         tutor local do importdemocourse
       shell: bash
 
+    - name: Populate Retirement States
+      run: |
+        source .tutor_venv/bin/activate
+
+        tutor local exec lms python manage.py lms populate_retirement_states
+      shell: bash
+
     - name: Test Open edX imports in plugin
       if: ${{ inputs.openedx_imports_test_file_path }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Python version to use.'
     required: false
     default: '3.11'
+  tutor_plugins:
+    description: "The list of Tutor plugins to install."
+    required: false
   shell_file_to_run:
     description: "The path of the shell file to run the integration tests."
     required: true
@@ -76,6 +79,14 @@ runs:
 
         tutor config save --set LMS_HOST=$LMS_HOST --set CMS_HOST=$CMS_HOST
         tutor local launch -I
+      shell: bash
+
+    - name: Enable Tutor plugins
+      if: ${{ inputs.tutor_plugins }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 
     - name: Configure Caddyfile and Open edX settings

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,8 @@ runs:
 
     - name: Launch Tutor
       run: |
+        source .tutor_venv/bin/activate
+
         tutor local launch -I
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,16 @@ runs:
         python -m venv .tests_venv
       shell: bash
 
+    - name: Install and enable Tutor plugins
+      if: ${{ inputs.tutor_plugins }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        tutor plugins update
+        tutor plugins install ${{ inputs.tutor_plugins }}
+        tutor plugins enable ${{ inputs.tutor_plugins }}
+      shell: bash
+
     - name: Install and prepare Tutor
       env:
         INPUT_TUTOR_VERSION: ${{ inputs.tutor_version }}
@@ -79,16 +89,6 @@ runs:
 
         tutor config save --set LMS_HOST=$LMS_HOST --set CMS_HOST=$CMS_HOST
         tutor local launch -I
-      shell: bash
-
-    - name: Enable Tutor plugins
-      if: ${{ inputs.tutor_plugins }}
-      run: |
-        source .tutor_venv/bin/activate
-
-        tutor plugins update
-        tutor plugins install ${{ inputs.tutor_plugins }}
-        tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 
     - name: Configure Caddyfile and Open edX settings

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
       run: |
         source .tutor_venv/bin/activate
 
+        tutor plugins update
         tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   tutor_plugins:
     description: "The list of Tutor indexed plugins to install. E.g: 'plugin1 plugin2'"
     required: false
+  tutor_extra_commands_path:
+    description: "The path of the shell file to run the Tutor extra commands."
+    required: false
   shell_file_to_run:
     description: "The path of the shell file to run the integration tests."
     required: true
@@ -154,13 +157,6 @@ runs:
         tutor local do importdemocourse
       shell: bash
 
-    - name: Populate Retirement States
-      run: |
-        source .tutor_venv/bin/activate
-
-        tutor local exec lms python manage.py lms populate_retirement_states
-      shell: bash
-
     - name: Test Open edX imports in plugin
       if: ${{ inputs.openedx_imports_test_file_path }}
       run: |
@@ -199,6 +195,16 @@ runs:
         else
           echo "DEMO_COURSE_ID=course-v1:OpenedX+DemoX+DemoCourse" >> $GITHUB_ENV
         fi
+      shell: bash
+
+    - name: Run Tutor extra commands
+      if: ${{ inputs.tutor_extra_commands_path }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        cd ${{ inputs.app_name }}
+        chmod +x ./${{ inputs.tutor_extra_commands_path }}
+        ./${{ inputs.tutor_extra_commands_path }}
       shell: bash
 
     - name: Run integration tests

--- a/action.yml
+++ b/action.yml
@@ -90,13 +90,6 @@ runs:
         tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 
-    - name: Launch Tutor
-      run: |
-        source .tutor_venv/bin/activate
-
-        tutor local launch -I
-      shell: bash
-
     - name: Configure Caddyfile and Open edX settings
       run: |
         source .tutor_venv/bin/activate
@@ -104,6 +97,13 @@ runs:
         mkdir -p plugins
         cp $GITHUB_ACTION_PATH/patches.yml plugins/
         tutor plugins enable patches
+      shell: bash
+
+    - name: Launch Tutor
+      run: |
+        source .tutor_venv/bin/activate
+
+        tutor local launch -I
       shell: bash
 
     - name: Add mount for Open edX plugin

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: '3.11'
   tutor_plugins:
-    description: "The list of Tutor plugins to install."
+    description: "The list of Tutor plugins to install. E.g: 'plugin1 plugin2'"
     required: false
   shell_file_to_run:
     description: "The path of the shell file to run the integration tests."


### PR DESCRIPTION
### Description
This PR adds two new steps in the action:

1. **Install Custom Tutor Plugins**: Some tests need to use specific Tutor plugins that are not installed by default. The particular plugins to install can be passed with the `tutor_plugins` input in each workflow that uses this action.
2. **Run Extra Tutor Commands**: Some tests need certain tables populated to function correctly. This new step allows you to add tutor commands to a shell script that will be executed before the integration tests. The particular shell file to run can be passed with the `tutor_extra_commands_path` input in each workflow that uses this action.

### Testing Instructions
You can test by opening a PR in any eox plugin and using this branch for the integration tests workflow. Here's an example:
- https://github.com/eduNEXT/eox-core/pull/300