### PR TITLE
feat: add input and step to install inline tutor plugins `AP-1547`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
           app_name: "eox-test"
           tutor_version: ${{ matrix.tutor_version }}
           tutor_plugins: "plugin1 plugin2"
+          inline_tutor_plugins_folder: "plugins"
           tutor_extra_commands_path: "scripts/extra_commands.sh"
           shell_file_to_run: "tests/integration.sh"
           openedx_extra_pip_requirements: "package1==1.0 package2>=2.0"
@@ -60,6 +61,12 @@ The python version to run the integration tests with. Make sure to use a version
 **Optional**  
 The list of Tutor Index plugins to install as a space-separated string. Only plugins available in the official Tutor plugin index can be installed using this option. For more information, you can refer to the [official Tutor documentation](https://docs.tutor.edly.io/reference/cli/plugins.html#tutor-plugins-install).
 * *Example*: `"plugin1 plugin2"`
+
+### `inline_tutor_plugins_folder`
+
+**Optional**  
+The path to the folder containing the inline Tutor plugins to install. This path is relative to your plugin directory. 
+* *Example*: `"plugins"`
 
 ### `tutor_extra_commands_path`
 
@@ -111,7 +118,7 @@ This GitHub Action automates the process of setting up a Tutor Open edX environm
    - If `tutor_version` is set to `"nightly"`, clones the Tutor repository from the `nightly` branch.
    - Saves Tutor configuration.
 
-7. **Install and Enable Tutor Plugins**: Installs and enables the specified Tutor plugins
+7. **Install and Enable Tutor Plugins** *(Optional)*: Installs and enables the specified Tutor plugins
 specified in `tutor_plugins`.
 
 8. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
@@ -124,19 +131,21 @@ specified in `tutor_plugins`.
 
 12. **Install Open edX Plugin as an Editable Package**: Installs your plugin in editable mode inside both LMS and CMS containers.
 
-13. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
+13. **Enable Inline Tutor Plugins**: Installs the Inline Tutor plugins inside the plugins folder.
 
-14. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
+14. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
 
-15. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
+15. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
 
-16. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
+16. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
 
-17. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
+17. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
 
-18. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
+18. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
 
-19. **Set `DEMO_COURSE_ID` Environment Variable**:  
+19. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
+
+20. **Set `DEMO_COURSE_ID` Environment Variable**:  
     Sets the `DEMO_COURSE_ID` environment variable based on the Tutor version. This variable allows you to refer to the demo course in your tests, which can be helpful when you need to interact with course content during testing.
     
     **Usage in Your Tests**:  
@@ -149,9 +158,9 @@ specified in `tutor_plugins`.
     # Use DEMO_COURSE_ID in your tests
     ```
 
-20. **Run Tutor Extra Commands** *(Optional)*: Executes the shell script specified in `tutor_extra_commands_path` to run additional Tutor commands after installing Tutor.
+21. **Run Tutor Extra Commands** *(Optional)*: Executes the shell script specified in `tutor_extra_commands_path` to run additional Tutor commands after installing Tutor.
 `
-21. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
+22. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The path to the folder containing the inline Tutor plugins to install. This path
 ### `tutor_extra_commands_path`
 
 **Optional**
-The path to the shell script that contains Tutor extra commands to run after installing Tutor. This path is relative to your plugin directory.
+The path to the shell script that contains extra Tutor commands to run after installing Tutor. This path is relative to your plugin directory.
 * *Example*: `"scripts/extra_commands.sh"`
 
 ### `shell_file_to_run`
@@ -109,43 +109,45 @@ This GitHub Action automates the process of setting up a Tutor Open edX environm
 
 3. **Adjust Permissions**: Modifies file permissions to ensure that all files and directories are accessible, preventing permission-related errors during Tutor operations.
 
-4. **Set Tutor Environment Variables**: Sets necessary environment variables for Tutor.
+4. **Set Up Plugins Directory**: Creates a directory to store the inline Tutor plugins.
 
-5. **Create Virtual Environments**: Creates isolated Python virtual environments for installing Tutor and for running the integration tests.
+5. **Set Tutor Environment Variables**: Sets necessary environment variables for Tutor.
 
-6. **Install and Prepare Tutor**: Installs the specified version of Tutor.
+6. **Create Virtual Environments**: Creates isolated Python virtual environments for installing Tutor and for running the integration tests.
+
+7. **Install and Prepare Tutor**: Installs the specified version of Tutor.
    
    - If `tutor_version` is set to `"nightly"`, clones the Tutor repository from the `nightly` branch.
    - Saves Tutor configuration.
 
-7. **Install and Enable Tutor Plugins** *(Optional)*: Installs and enables the specified Tutor plugins
-specified in `tutor_plugins`.
+8. **Install and Enable Tutor Plugins** *(Optional)*: Installs and enables the specified Tutor plugins
+specified in `tutor_plugins` input.
 
-8. **Configure Caddyfile and Open edX Settings**: Configures the web server and Open edX settings using Tutor plugins, to enable running integration tests from the plugin with multiple sites.
+9. **Copy patches.yml to Plugins Directory**: Copies the patches.yml file to the plugins folder. This inline Tutor plugin configures the web server and Open edX settings, to enable running integration tests from the plugin with multiple sites.
 
-9. **Launch Tutor**: Launches the Open edX platform using Tutor with the specified configuration.
+10. **Launch Tutor**: Launches the Open edX platform using Tutor with the specified configuration.
 
-10. **Add Mount for Plugin**: Mounts your plugin into the LMS and CMS containers.
+11. **Add Mount for Plugin**: Mounts your plugin into the LMS and CMS containers.
 
-11. **Restart Tutor Services**: Stops and starts Tutor services to apply the new mounts.
+12. **Recreate Containers**: Recreates the LMS and CMS containers to apply the changes.
 
-12. **Install Open edX Plugin as an Editable Package**: Installs your plugin in editable mode inside both LMS and CMS containers.
+13. **Install Open edX Plugin as an Editable Package**: Installs your plugin in editable mode inside both LMS and CMS containers.
 
-13. **Enable Inline Tutor Plugins**: Installs the Inline Tutor plugins inside the plugins folder.
+14. **Enable Inline Tutor Plugins**: Installs the Inline Tutor plugins inside the plugins folder.
 
-14. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
+15. **Install Extra Requirements**: Installs any additional Python packages specified in `openedx_extra_pip_requirements`.
 
-15. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
+16. **Run Migrations and Restart Services**: Applies database migrations and restarts Tutor services.
 
-16. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
+17. **Import Demo Course**: Imports the Open edX demo course for testing purposes.
 
-17. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
+18. **Test Open edX Imports in Plugin** *(Optional)*: Runs pytest to validate Open edX imports in your plugin if `openedx_imports_test_file_path` is provided. The only two dependencies installed to run these tests are `pytest` and `pytest-django`, so ensure that your import tests do not require any extra packages that are not in the plugin's base requirements.
 
-18. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
+19. **Load Initial Data for the Tests** *(Optional)*: Loads initial data from a fixtures file into the LMS if `fixtures_file` is provided.
 
-19. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
+20. **Check LMS Heartbeat**: Verifies that the LMS is running by hitting the heartbeat endpoint.
 
-20. **Set `DEMO_COURSE_ID` Environment Variable**:  
+21. **Set `DEMO_COURSE_ID` Environment Variable**:  
     Sets the `DEMO_COURSE_ID` environment variable based on the Tutor version. This variable allows you to refer to the demo course in your tests, which can be helpful when you need to interact with course content during testing.
     
     **Usage in Your Tests**:  
@@ -158,9 +160,9 @@ specified in `tutor_plugins`.
     # Use DEMO_COURSE_ID in your tests
     ```
 
-21. **Run Tutor Extra Commands** *(Optional)*: Executes the shell script specified in `tutor_extra_commands_path` to run additional Tutor commands after installing Tutor.
-`
-22. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
+22. **Run Extra Tutor Commands** *(Optional)*: Executes the shell script specified in `tutor_extra_commands_path` to run additional Tutor commands after installing Tutor.
+
+23. **Run Integration Tests**: Activates the test virtual environment and runs your integration tests using the specified shell script.
 
 ## Notes
 
@@ -169,7 +171,7 @@ specified in `tutor_plugins`.
 
 - **Paths**: Ensure that the paths provided in the inputs are relative to your plugin directory.
 
-- **Optional Steps**: Steps involving `openedx_imports_test_file_path`, `fixtures_file`, `tutor_extra_commands_path` and `tutor_plugins` are optional and will only run if the corresponding inputs are provided.
+- **Optional Steps**: Steps involving `openedx_imports_test_file_path`, `openedx_extra_pip_requirements`, `fixtures_file`, `tutor_extra_commands_path` and `tutor_plugins` are optional and will only run if the corresponding inputs are provided.
 
 - **Tutor Versions**: Use the matrix strategy to test your plugin against multiple Tutor versions, including the nightly build.
 

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,11 @@
 name: Open edX Plugin Integration Tests with Tutor
-description: "A Github action to test your Open edX plugin in Tutor"
+description: 'A Github action to test your Open edX plugin in Tutor'
 inputs:
   app_name:
-    description: "Open edX plugin or application name to test. E.g., eox-tenant."
+    description: 'Open edX plugin or application name to test. E.g., eox-tenant.'
     required: true
   tutor_version:
-    description: "The tutor version matrix to use."
+    description: 'The tutor version matrix to use.'
     required: true
   python_version:
     description: 'Python version to use.'
@@ -14,13 +14,16 @@ inputs:
   tutor_plugins:
     description: "The list of Tutor indexed plugins to install. E.g: 'plugin1 plugin2'"
     required: false
+  inline_tutor_plugins_folder:
+    description: "Optional path to the folder containing the inline Tutor plugins to install. E.g: 'plugins'"
+    required: false
   tutor_extra_commands_path:
-    description: "The path of the shell file to run the Tutor extra commands."
+    description: 'The path of the shell file to run the Tutor extra commands.'
     required: false
   shell_file_to_run:
-    description: "The path of the shell file to run the integration tests."
+    description: 'The path of the shell file to run the integration tests.'
     required: true
-    default: "scripts/execute_integration_tests.sh"
+    default: 'scripts/execute_integration_tests.sh'
   openedx_extra_pip_requirements:
     description: "Optional extra pip requirements to install in Open edX. E.g: 'package1==1.0 package2>=2.0'"
     required: false
@@ -28,11 +31,11 @@ inputs:
     description: "Optional path to the plugin's fixtures file to load."
     required: false
   openedx_imports_test_file_path:
-    description: "Path to the file that contains the test function for validating Open edX imports. This should be a Python file within your project."
+    description: 'Path to the file that contains the test function for validating Open edX imports. This should be a Python file within your project.'
     required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set Up Python
       uses: actions/setup-python@v5
@@ -130,6 +133,22 @@ runs:
 
         tutor local exec lms pip install -e /openedx/${{ inputs.app_name }}/
         tutor local exec cms pip install -e /openedx/${{ inputs.app_name }}/
+      shell: bash
+
+    - name: Enable Inline Tutor plugins
+      env:
+        INLINE_TUTOR_PLUGINS_PATH: ${{ inputs.app_name }}/${{ inputs.inline_tutor_plugins_folder }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        if [ -d "$INLINE_TUTOR_PLUGINS_PATH" ]; then
+          cp -r "$INLINE_TUTOR_PLUGINS_PATH"/* plugins/
+        fi
+
+        for plugin_file in plugins/*; do
+          plugin_name=$(basename "$plugin_file" | cut -f1 -d '.')
+          tutor plugins enable "$plugin_name"
+        done
       shell: bash
 
     - name: Install extra requirements

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "Optional path to the folder containing the inline Tutor plugins to install. E.g: 'plugins'"
     required: false
   tutor_extra_commands_path:
-    description: 'The path of the shell file to run the Tutor extra commands.'
+    description: 'The path of the shell file to run the extra Tutor commands.'
     required: false
   shell_file_to_run:
     description: 'The path of the shell file to run the integration tests.'
@@ -50,6 +50,11 @@ runs:
     - name: Adjust permissions to execute Tutor commands
       run: |
         chmod 777 . -R
+      shell: bash
+
+    - name: Set Up plugins directory
+      run: |
+        mkdir -p plugins
       shell: bash
 
     - name: Set Tutor environment variables
@@ -86,7 +91,7 @@ runs:
         tutor config save --set LMS_HOST=$LMS_HOST --set CMS_HOST=$CMS_HOST
       shell: bash
 
-    - name: Install and enable Tutor plugins
+    - name: Install and enable Tutor index plugins
       if: ${{ inputs.tutor_plugins }}
       run: |
         source .tutor_venv/bin/activate
@@ -96,13 +101,11 @@ runs:
         tutor plugins enable ${{ inputs.tutor_plugins }}
       shell: bash
 
-    - name: Configure Caddyfile and Open edX settings
+    - name: Copy patches.yml to plugins directory
       run: |
         source .tutor_venv/bin/activate
 
-        mkdir -p plugins
         cp $GITHUB_ACTION_PATH/patches.yml plugins/
-        tutor plugins enable patches
       shell: bash
 
     - name: Launch Tutor
@@ -135,7 +138,7 @@ runs:
         tutor local exec cms pip install -e /openedx/${{ inputs.app_name }}/
       shell: bash
 
-    - name: Enable Inline Tutor plugins
+    - name: Enable inline Tutor plugins
       env:
         INLINE_TUTOR_PLUGINS_PATH: ${{ inputs.app_name }}/${{ inputs.inline_tutor_plugins_folder }}
       run: |
@@ -216,7 +219,7 @@ runs:
         fi
       shell: bash
 
-    - name: Run Tutor extra commands
+    - name: Run extra Tutor commands
       if: ${{ inputs.tutor_extra_commands_path }}
       run: |
         source .tutor_venv/bin/activate
@@ -227,7 +230,6 @@ runs:
       shell: bash
 
     - name: Run integration tests
-      if: ${{ inputs.shell_file_to_run }}
       env:
         DEMO_COURSE_ID: ${{ env.DEMO_COURSE_ID }}
       run: |


### PR DESCRIPTION
### Description
This PR adds a new step to install inline Tutor plugins in the environment. This change is mainly because some tests need specific settings, such as adding middleware to the environment. The particular inline plugins to install can be passed with the `inline_tutor_plugins_folder` input in each workflow that uses this action.

### Testing Instructions
You can test by opening a PR in any eox plugin and using this branch for the integration tests workflow. Here's an example:
- https://github.com/eduNEXT/eox-core/pull/298