### PR TITLE
feat: add 'enable_plugins_before_start' toggle for resource optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ The list of Tutor Index plugins to install as a space-separated string. Only plu
 The path to the folder containing the inline Tutor plugins to install. This path is relative to your plugin directory. 
 * *Example*: `"plugins"`
 
+### `enable_plugins_before_init`
+
+**Optional**  
+If `true`, enables inline plugins before initializing Tutor. This is heavier on resources but required when a plugin must patch Tutor early in the startup sequence (e.g., to adjust settings before services are built). Default: `false`.
+
 ### `tutor_extra_commands_path`
 
 **Optional**

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   inline_tutor_plugins_folder:
     description: "Optional path to the folder containing the inline Tutor plugins to install. E.g: 'plugins'"
     required: false
+  enable_plugins_before_init:
+    description: "If 'true', enables plugins BEFORE initializing Tutor. If 'false', enables them at the end."
+    required: false
+    default: 'false'
   tutor_extra_commands_path:
     description: 'The path of the shell file to run the extra Tutor commands.'
     required: false
@@ -108,6 +112,14 @@ runs:
         cp $GITHUB_ACTION_PATH/patches.yml plugins/
       shell: bash
 
+    - name: (Pre-Init) Setup inline Tutor plugins
+      if: ${{ inputs.inline_tutor_plugins_folder && inputs.enable_plugins_before_init == 'true' }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        bash "$GITHUB_ACTION_PATH/scripts/enable_inline_tutor_plugins.sh" "${{ inputs.app_name }}" "${{ inputs.inline_tutor_plugins_folder }}"
+      shell: bash
+
     - name: Launch Tutor
       run: |
         source .tutor_venv/bin/activate
@@ -127,25 +139,7 @@ runs:
         tutor mounts add "cms:$GITHUB_WORKSPACE/${{ inputs.app_name }}:/openedx/${{ inputs.app_name }}"
       shell: bash
 
-    - name: Copy inline Tutor plugins to the plugins directory
-      if: ${{ inputs.inline_tutor_plugins_folder }}
-      run: |
-        source .tutor_venv/bin/activate
-
-        cp -r "${{ inputs.app_name }}/${{ inputs.inline_tutor_plugins_folder }}"/* plugins/
-      shell: bash
-
-    - name: Enable inline Tutor plugins
-      run: |
-        source .tutor_venv/bin/activate
-
-        for plugin_file in plugins/*; do
-          plugin_name=$(basename "$plugin_file" | cut -f1 -d '.')
-          tutor plugins enable "$plugin_name"
-        done
-      shell: bash
-
-    - name: Recreate containers to apply mounts and plugins
+    - name: Recreate containers to apply mounts
       run: |
         source .tutor_venv/bin/activate
 
@@ -158,6 +152,14 @@ runs:
 
         tutor local exec lms pip install -e /openedx/${{ inputs.app_name }}/
         tutor local exec cms pip install -e /openedx/${{ inputs.app_name }}/
+      shell: bash
+
+    - name: (Post-Init) Setup inline Tutor plugins
+      if: ${{ inputs.inline_tutor_plugins_folder && inputs.enable_plugins_before_init != 'true' }}
+      run: |
+        source .tutor_venv/bin/activate
+
+        bash "$GITHUB_ACTION_PATH/scripts/enable_inline_tutor_plugins.sh" "${{ inputs.app_name }}" "${{ inputs.inline_tutor_plugins_folder }}"
       shell: bash
 
     - name: Install extra requirements

--- a/scripts/enable_inline_tutor_plugins.sh
+++ b/scripts/enable_inline_tutor_plugins.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_name="$1"
+inline_folder="$2"
+
+source .tutor_venv/bin/activate
+cp -r "${app_name}/${inline_folder}"/. plugins/
+
+for plugin_file in plugins/*; do
+  plugin_name="$(basename "$plugin_file" | cut -f1 -d '.')"
+  tutor plugins enable "$plugin_name"
+


### PR DESCRIPTION
Recently, we observed that moving the inline plugin enablement before the tutor local start command caused intermittent failures in our CI/CD pipelines. Specifically, the runners were experiencing resource exhaustion (OOM Kill) during the tutor local do init phase, as Tutor attempted to render and initialize the entire ecosystem with all extensions active from the start.

However, some integration tests (such as those involving tenant logic in eox-core) may require plugins to be active from the very first boot to avoid state inconsistencies.

## Changes
This PR introduces a new input parameter: `enable_plugins_before_start` (default: false).

Conditional Execution Paths:

- Default (false): Plugins are copied and enabled after the initial Tutor start/init. This is the "lightweight" mode that prevents OOM issues by keeping the initial boot process pure.
- Opt-in (true): Plugins are enabled before the initial start. This is the "complete" mode for tests that require all plugins to be present during the initialization phase.

### Refactoring:
Merged the "Copy" and "Enable" steps into a single logical block for both paths to reduce step noise in the GitHub Actions UI and improve maintainability.

### Resource Management:
By defaulting to false, we ensure that most PRs pass without hitting the 7GB RAM limit of GitHub runners.

## How to Test
### Scenario 1: Default Behavior (Lightweight) In a test repository, use the action without the new flag:

```yaml
uses: eduNEXT/integration-test-in-tutor@v0.1.2
with:
  app_name: eox-core
  tutor_version: "18.1.0"
  # enable_plugins_before_start defaults to 'false'
```
Expected Result: The pipeline should consume less memory during the Launch Tutor step and pass successfully.

### Scenario 2: Pre-Start Enablement (For complex state tests) Manually set the flag to true:

```yaml
uses: eduNEXT/integration-test-in-tutor@v0.1.2
with:
  app_name: eox-core
  tutor_version: "18.1.0"
  enable_plugins_before_start: "true"
```
Expected Result: Plugins are enabled before tutor local do init. Verify that the logs show the plugins being enabled before the main launch. Note: Use this if Scenario 1 causes test logic failures like the one reported in `test_update_username_in_tenant_success`.

## Dependencies
This change is intended to replace the temporary pinning of the action version in eox-core.